### PR TITLE
avoid RPi detection in picamera pip install

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@ ENV INITSYSTEM on
 # pip install python deps from requirements.txt
 # For caching until requirements.txt changes
 COPY ./requirements.txt /requirements.txt
-RUN pip install -r /requirements.txt
+RUN READTHEDOCS=True pip install -r /requirements.txt
 
 COPY . /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
It seems that the picamera project now detects if it's being installed on actual RPi hardware and barfs if it's not.  Since the resin.io builder is not a Pi, this now breaks.  Setting the READTHEDOCS environment variable to 'True' skips this test.